### PR TITLE
Fix version name and date in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ When you need to provide the contents of your domain private key, you can add yo
 - **2019-07-26** rippled 1.4.0 [is released](https://xrpl.org/blog/2019/rippled-1.4.0.html)
 - **2020-04-01** rippled 1.5.0 [is released](https://xrpl.org/blog/2020/rippled-1.5.0.html)
 - **2020-08-19** rippled 1.6.0 [is released](https://xrpl.org/blog/2020/rippled-1.6.0.html)
-- **2020-08-19** rippled 1.6.0 [is released](https://xrpl.org/blog/2021/rippled-1.7.0.html)
+- **2021-02-24** rippled 1.7.0 [is released](https://xrpl.org/blog/2021/rippled-1.7.0.html)
 
 ## Update process
 


### PR DESCRIPTION
The newly released version 1.7.0 was referred to by the previous version.